### PR TITLE
更新springboot版本到2.4.10, springcloud版本到2020.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.0.RELEASE</version>
+        <version>2.4.10</version>
         <relativePath/>
     </parent>
 
@@ -128,7 +128,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>2020.0.2</version>
+                <version>2020.0.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/test/java/com/acech/demo/ApplicationTest.java
+++ b/src/test/java/com/acech/demo/ApplicationTest.java
@@ -1,14 +1,15 @@
 package com.acech.demo;
 
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * @author wahcen@163.com
  * @date 2021/8/29 2:39
  */
 @SpringBootTest
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class ApplicationTest {
 }

--- a/src/test/java/com/acech/demo/cglib/CgLibTest.java
+++ b/src/test/java/com/acech/demo/cglib/CgLibTest.java
@@ -14,8 +14,8 @@ import net.sf.cglib.proxy.InvocationHandler;
 import net.sf.cglib.proxy.MethodInterceptor;
 import net.sf.cglib.proxy.MethodProxy;
 import net.sf.cglib.proxy.NoOp;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 
@@ -72,11 +72,7 @@ public class CgLibTest {
         // getClass是final方法，无法拦截
         System.out.println(proxy.getClass());
         // ClassCastException 拦截返回了字符串而不是数字
-        try {
-            System.out.println(proxy.hashCode());
-        } catch (ClassCastException e) {
-            // Method should reach here
-        }
+        Assertions.assertThrows(ClassCastException.class, () -> System.out.println(proxy.hashCode()));
     }
 
     /**
@@ -102,14 +98,8 @@ public class CgLibTest {
             }
         });
         CgLibDemo demo = (CgLibDemo) enhancer.create();
-        Assert.assertEquals("hello cglib", demo.test(null));
-        try {
-            // method.getDeclaringClass == Object.class，抛出异常
-            Assert.assertNotEquals("Hello cglib", demo.toString());
-        } catch (RuntimeException e) {
-            // Method should reach here
-            Assert.assertEquals("异常", e.getMessage());
-        }
+        Assertions.assertEquals("hello cglib", demo.test(null));
+        Assertions.assertThrows(RuntimeException.class, demo::toString);
     }
 
     /**
@@ -140,9 +130,9 @@ public class CgLibTest {
         enhancer.setCallbackFilter(callbackHelper);
         CgLibDemo demo = (CgLibDemo) enhancer.create();
         // 方法被拦截
-        Assert.assertEquals("Hello cglib", demo.test(null));
+        Assertions.assertEquals("Hello cglib", demo.test(null));
         // toString()的调用class是Object，放行
-        Assert.assertNotEquals("Hello cglib", demo.toString());
+        Assertions.assertNotEquals("Hello cglib", demo.toString());
         System.out.println(demo.hashCode());
     }
 
@@ -158,15 +148,11 @@ public class CgLibTest {
         CgLibBeanDemo demo = new CgLibBeanDemo();
         demo.setValue("Hello world");
         CgLibBeanDemo immutableDemo = (CgLibBeanDemo) ImmutableBean.create(demo);
-        Assert.assertEquals("Hello world", immutableDemo.getValue());
+        Assertions.assertEquals("Hello world", immutableDemo.getValue());
         // 可以通过原始对象修改
         demo.setValue("Hello world, again");
-        Assert.assertEquals("Hello world, again", immutableDemo.getValue());
-        try {
-            immutableDemo.setValue("Changed Value");
-        } catch (IllegalStateException e) {
-            // Method should reach here
-        }
+        Assertions.assertEquals("Hello world, again", immutableDemo.getValue());
+        Assertions.assertThrows(IllegalStateException.class, () -> immutableDemo.setValue("Changed Value"));
     }
 
     /**
@@ -183,7 +169,7 @@ public class CgLibTest {
         setter.invoke(rawBean, 12345);
         // 获取getter并输出
         Method getter = rawBean.getClass().getMethod("getUserId");
-        Assert.assertEquals(12345, getter.invoke(rawBean));
+        Assertions.assertEquals(12345, getter.invoke(rawBean));
     }
 
     /**
@@ -220,7 +206,7 @@ public class CgLibTest {
                 return o;
             }
         });
-        Assert.assertEquals("Hello cglib", copiedDemo.getValue());
+        Assertions.assertEquals("Hello cglib", copiedDemo.getValue());
     }
 
     /**
@@ -237,10 +223,10 @@ public class CgLibTest {
         demo.setValue("Hello bulkBean");
         // 等价于bulkBean.getPropertyValues(demo, [...getters])
         Object[] propertyValues = bulkBean.getPropertyValues(demo);
-        Assert.assertEquals(1, propertyValues.length);
-        Assert.assertEquals("Hello bulkBean", propertyValues[0]);
+        Assertions.assertEquals(1, propertyValues.length);
+        Assertions.assertEquals("Hello bulkBean", propertyValues[0]);
         bulkBean.setPropertyValues(demo, new Object[] {"Hello cglib"});
-        Assert.assertEquals("Hello cglib", demo.getValue());
+        Assertions.assertEquals("Hello cglib", demo.getValue());
     }
 
     /**
@@ -267,12 +253,12 @@ public class CgLibTest {
         passwordSetter.invoke(bean, "12345");
         // 获取bean的BeanMap
         BeanMap map = BeanMap.create(bean);
-        Assert.assertEquals("admin", map.get("username"));
+        Assertions.assertEquals("admin", map.get("username"));
         // 修改bean的属性值
         map.put("username", "administrator");
         map.put("value", "changedDemoValue");
-        Assert.assertEquals("administrator", bean.getClass().getMethod("getUsername").invoke(bean));
-        Assert.assertEquals("changedDemoValue", bean.getClass().getMethod("getValue").invoke(bean));
-        Assert.assertEquals("12345", map.get("password"));
+        Assertions.assertEquals("administrator", bean.getClass().getMethod("getUsername").invoke(bean));
+        Assertions.assertEquals("changedDemoValue", bean.getClass().getMethod("getValue").invoke(bean));
+        Assertions.assertEquals("12345", map.get("password"));
     }
 }

--- a/src/test/java/com/acech/demo/redis/RedisTest.java
+++ b/src/test/java/com/acech/demo/redis/RedisTest.java
@@ -9,8 +9,8 @@ import com.acech.demo.util.RObject;
 import com.acech.demo.util.RedisClient;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
@@ -69,22 +69,22 @@ public class RedisTest extends ApplicationTest {
         if (demoRObject.setIfAbsent(demo)) {
             demoRObject.clear();
         }
-        Assert.assertNull(demoRObject.get());
+        Assertions.assertNull(demoRObject.get());
 
         demoRObject.set(demo, 3000);
         TimeUnit.SECONDS.sleep(5);
-        Assert.assertNull(demoRObject.get());
+        Assertions.assertNull(demoRObject.get());
 
         demoRObject.set(demo);
         Demo retDemo = demoRObject.get();
-        Assert.assertEquals(demo.getId(), retDemo.getId());
-        Assert.assertEquals(demo.getName(), retDemo.getName());
+        Assertions.assertEquals(demo.getId(), retDemo.getId());
+        Assertions.assertEquals(demo.getName(), retDemo.getName());
 
         strRObject.set("This is a string object.");
-        Assert.assertEquals(strRObject.getAndSet("This is a new string object."), "This is a string object.");
-        Assert.assertEquals(strRObject.get(), "This is a new string object.");
+        Assertions.assertEquals(strRObject.getAndSet("This is a new string object."), "This is a string object.");
+        Assertions.assertEquals(strRObject.get(), "This is a new string object.");
         strRObject.ifPresent(log::info);
-        Assert.assertEquals(strRObject.orElse("Equal"), strRObject.get());
+        Assertions.assertEquals(strRObject.orElse("Equal"), strRObject.get());
     }
 
     @Test
@@ -94,16 +94,16 @@ public class RedisTest extends ApplicationTest {
         demoRMap.put("demo02", DemoFactory.randomDemo());
         demoRMap.put("demo03", DemoFactory.randomDemo());
         demoRMap.put("demo04", DemoFactory.newDemo(4, "yes"));
-        Assert.assertEquals(demoRMap.get("demo04").getName(), "yes");
-        Assert.assertEquals(demoRMap.size(), 4);
-        Assert.assertTrue(demoRMap.containsKey("demo01"));
-        Assert.assertTrue(demoRMap.containsValue(DemoFactory.newDemo(4, "yes")));
+        Assertions.assertEquals(demoRMap.get("demo04").getName(), "yes");
+        Assertions.assertEquals(demoRMap.size(), 4);
+        Assertions.assertTrue(demoRMap.containsKey("demo01"));
+        Assertions.assertTrue(demoRMap.containsValue(DemoFactory.newDemo(4, "yes")));
         demoRMap.entrySet().forEach(e -> log.info("Entry: {}", e));
         demoRMap.keySet().forEach(k -> log.info("Key: {}", k));
         demoRMap.values().forEach(v -> log.info("Value: {}", v));
         demoRMap.clear();
-        Assert.assertTrue(demoRMap.isEmpty());
-        Assert.assertNull(demoRMap.remove("demo01"));
+        Assertions.assertTrue(demoRMap.isEmpty());
+        Assertions.assertNull(demoRMap.remove("demo01"));
     }
 
     @Test
@@ -118,20 +118,20 @@ public class RedisTest extends ApplicationTest {
 
         Demo demo = demoRList.get(1);
         log.info("Removed: {} {}", demo, demoRList.remove(demo));
-        Assert.assertFalse(demoRList.contains(demo));
-        Assert.assertTrue(demoRList.contains(demoRList.get(0)));
+        Assertions.assertFalse(demoRList.contains(demo));
+        Assertions.assertTrue(demoRList.contains(demoRList.get(0)));
         log.info("Removed: {}", demoRList.remove(1));
-        Assert.assertEquals(demoRList.size(), 2);
+        Assertions.assertEquals(demoRList.size(), 2);
         if (!demoRList.isEmpty()) {
             demoRList.add(0, DemoFactory.randomDemo());
-            Assert.assertEquals(demoRList.size(), 3);
+            Assertions.assertEquals(demoRList.size(), 3);
             demoRList.addAll(2, Arrays.asList(DemoFactory.randomDemo(), DemoFactory.randomDemo()));
-            Assert.assertEquals(demoRList.size(), 5);
+            Assertions.assertEquals(demoRList.size(), 5);
             demoRList.set(0, DemoFactory.newDemo(1, "test"));
-            Assert.assertEquals(demoRList.get(0).getName(), "test");
+            Assertions.assertEquals(demoRList.get(0).getName(), "test");
             demoRList.forEach(item -> log.info("List item: {}", item));
             demoRList.clear();
-            Assert.assertTrue(demoRList.isEmpty());
+            Assertions.assertTrue(demoRList.isEmpty());
         }
     }
 }


### PR DESCRIPTION
springboot-parent版本低于2.2.0时, actuator与openfeign不兼容
具体体现在ClassNotFoundException:CompositeHealthContributor
低版本actuator没有该类, feign的DiscoveryCompositeHealthContributor实现了该接口

Signed-off-by: acech <wahcen@163.com>